### PR TITLE
Pull request: optional axis labels

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject dtolpin/gorilla-plot "0.1.4-SPANSHOT"
+(defproject dtolpin/gorilla-plot "0.1.4-SNAPSHOT"
   :description "A simple data-driven plotting library for Gorilla REPL."
   :url "https://github.com/JonyEpsilon/gorilla-plot"
   :license {:name "MIT"}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject dtolpin/gorilla-plot "0.1.4-SNAPSHOT"
+(defproject gorilla-plot "0.1.4-SNAPSHOT"
   :description "A simple data-driven plotting library for Gorilla REPL."
   :url "https://github.com/JonyEpsilon/gorilla-plot"
   :license {:name "MIT"}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject gorilla-plot "0.1.3"
+(defproject dtolpin/gorilla-plot "0.1.4-SPANSHOT"
   :description "A simple data-driven plotting library for Gorilla REPL."
   :url "https://github.com/JonyEpsilon/gorilla-plot"
   :license {:name "MIT"}

--- a/src/gorilla_plot/core.clj
+++ b/src/gorilla_plot/core.clj
@@ -15,7 +15,7 @@
 
 (defn list-plot
   "Function for plotting list data."
-  [data & {:keys [joined plot-size aspect-ratio colour color plot-range #_symbol symbol-size opacity]
+  [data & {:keys [joined plot-size aspect-ratio colour color plot-range #_symbol symbol-size opacity x-title y-title]
            :or   {joined       false
                   plot-size    400
                   aspect-ratio 1.618
@@ -35,7 +35,7 @@
                         (vega/line-plot-marks series-name (or colour color) opacity)
                         (vega/list-plot-marks series-name (or colour color) #_symbol symbol-size opacity))
                       (vega/default-list-plot-scales series-name plot-range)
-                      (vega/default-plot-axes)))))
+                      (vega/default-plot-axes x-title y-title)))))
 
 
 (defn plot
@@ -50,7 +50,7 @@
 
 
 (defn bar-chart
-  [categories values & {:keys [plot-size aspect-ratio colour color plot-range opacity]
+  [categories values & {:keys [plot-size aspect-ratio colour color plot-range opacity x-title y-title]
                         :or   {plot-size    400
                                aspect-ratio 1.618
                                plot-range   [:all :all]
@@ -62,12 +62,12 @@
                       (vega/data-from-list series-name (map vector categories values))
                       (vega/bar-chart-marks series-name (or colour color) opacity)
                       (vega/default-bar-chart-scales series-name plot-range)
-                      (vega/default-plot-axes)))))
+                      (vega/default-plot-axes x-title y-title)))))
 
 
 (defn histogram
   "Plot the histogram of a sample."
-  [data & {:keys [plot-range bins normalize normalise plot-size aspect-ratio colour color opacity fill-opacity]
+  [data & {:keys [plot-range bins normalize normalise plot-size aspect-ratio colour color opacity fill-opacity x-title y-title]
            :or   {plot-range   [:all :all]
                   bins         :automatic
                   plot-size    400
@@ -110,7 +110,7 @@
                         (vega/data-from-list series-name plot-data)
                         (vega/histogram-marks series-name (or colour color) opacity fill-opacity)
                         (vega/default-list-plot-scales series-name plot-range)
-                        (vega/default-plot-axes))))))
+                        (vega/default-plot-axes x-title y-title))))))
 
 (defn compose
   [& plots]

--- a/src/gorilla_plot/vega.clj
+++ b/src/gorilla_plot/vega.clj
@@ -7,11 +7,17 @@
 (ns gorilla-plot.vega
   (:require [gorilla-repl.vega :as vega]))
 
+;; Constants for padding and offsets are chosen so
+;; that simple axis titles are visible and do not
+;; obstruct axis labels, for common ranges. A smarter
+;; dynamic approach is probably possible, but for most
+;; practical cases this is sufficient.
+
 (defn container
   [plot-size aspect-ratio]
   {:width   plot-size
    :height  (float (/ plot-size aspect-ratio))
-   :padding {:top 10, :left 50, :bottom 40, :right 10}})
+   :padding {:top 10, :left 55, :bottom 40, :right 10}})
 
 (defn data-from-list
   [data-key data]
@@ -22,9 +28,9 @@
 (defn default-plot-axes
   [x-title y-title]
   {:axes [(merge {:type "x" :scale "x"}
-                 (when x-title {:title x-title}))
+                 (when x-title {:title x-title :titleOffset 30}))
           (merge {:type "y" :scale "y"}
-                 (when y-title {:title y-title :titleOffset 40}))]})
+                 (when y-title {:title y-title :titleOffset 45}))]})
 
 ;;; Scatter/list plots
 

--- a/src/gorilla_plot/vega.clj
+++ b/src/gorilla_plot/vega.clj
@@ -11,7 +11,7 @@
   [plot-size aspect-ratio]
   {:width   plot-size
    :height  (float (/ plot-size aspect-ratio))
-   :padding {:top 10, :left 50, :bottom 20, :right 10}})
+   :padding {:top 10, :left 40, :bottom 40, :right 10}})
 
 (defn data-from-list
   [data-key data]

--- a/src/gorilla_plot/vega.clj
+++ b/src/gorilla_plot/vega.clj
@@ -11,7 +11,7 @@
   [plot-size aspect-ratio]
   {:width   plot-size
    :height  (float (/ plot-size aspect-ratio))
-   :padding {:top 10, :left 40, :bottom 40, :right 10}})
+   :padding {:top 10, :left 50, :bottom 40, :right 10}})
 
 (defn data-from-list
   [data-key data]
@@ -24,7 +24,7 @@
   {:axes [(merge {:type "x" :scale "x"}
                  (when x-title {:title x-title}))
           (merge {:type "y" :scale "y"}
-                 (when y-title {:title y-title}))]})
+                 (when y-title {:title y-title :titleOffset 40}))]})
 
 ;;; Scatter/list plots
 

--- a/src/gorilla_plot/vega.clj
+++ b/src/gorilla_plot/vega.clj
@@ -20,9 +20,11 @@
    })
 
 (defn default-plot-axes
-  []
-  {:axes [{:type "x" :scale "x"}
-          {:type "y" :scale "y"}]})
+  [x-title y-title]
+  {:axes [(merge {:type "x" :scale "x"}
+                 (when x-title {:title x-title}))
+          (merge {:type "y" :scale "y"}
+                 (when y-title {:title y-title}))]})
 
 ;;; Scatter/list plots
 


### PR DESCRIPTION
axis labels can be optionally specified for plots, by supplying values to :x-title and/or :y-title. When omitted, no axis labels are added, reverting to the previous behavior. To accommodate for the X axis label, the X padding was increased from 20 to 50 units.
